### PR TITLE
fix: hpa enabled for testing

### DIFF
--- a/chart/templates/hpa.yaml
+++ b/chart/templates/hpa.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2beta2 
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "badgr.fullname" . }}-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    name: {{ include "badgr.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics: 
+  - type: Resource
+    resource:
+      name: cpu 
+      target:
+        type: Utilization 
+        averageUtilization: 80
+  - type: Resource
+    resource:
+      name: memory 
+      target:
+        type: Utilization 
+        averageUtilization: 80
+  behavior:
+    scaleDown:
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+      stabilizationWindowSeconds: 300
+    scaleUp:
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+      stabilizationWindowSeconds: 0
+{{ end }} 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -63,14 +63,14 @@ mysql:
 managed_mysql:
   # disabled: true - to use in-cluster database
   # disabled: false - use managed RDBMS database 
-  disabled: false
+  disabled: true
   # values will be overridden by the config repo based on the namespace
   # different values for database will be available in values-*.yaml file from the config repo
   auth:
-    username: badgradmindev
-    password: zAxc%768@![DgHF0*
-    database: badgr
-    host: badgr-mysql-test.mysql.database.azure.com
+    username:
+    password:
+    database:
+    host:
     port: 3306
 
 hpa:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -63,18 +63,18 @@ mysql:
 managed_mysql:
   # disabled: true - to use in-cluster database
   # disabled: false - use managed RDBMS database 
-  disabled: true
+  disabled: false
   # values will be overridden by the config repo based on the namespace
   # different values for database will be available in values-*.yaml file from the config repo
   auth:
-    username: 
-    password: 
-    database: 
-    host: 
+    username: badgradmindev
+    password: zAxc%768@![DgHF0*
+    database: badgr
+    host: badgr-mysql-test.mysql.database.azure.com
     port: 3306
 
 hpa:
-  enabled: true
+  enabled: false
   minReplicas: 1
   maxReplicas: 5
   cpuTarget: 200m

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -74,7 +74,7 @@ managed_mysql:
     port: 3306
 
 hpa:
-  enabled: false
+  enabled: true
   minReplicas: 1
   maxReplicas: 5
   cpuTarget: 200m


### PR DESCRIPTION
This PR is to merge the tested hpa config in the process of refactoring the badgr-server and simplifying the helm chart . The subbranch dev-charts-hpa is used for testing both hpa config and managed DB config 

![image](https://user-images.githubusercontent.com/53479552/165899652-53d86c9a-a35a-47cb-b08c-8821e944fab6.png)
![image](https://user-images.githubusercontent.com/53479552/165901361-83c36c64-6917-417a-81ba-5d0f066ac4cc.png)

Build Job URL
https://jenkins-labs-ci-cd.apps.dev.lxp.academy.who.int/job/badgr-server/job/dev-charts-hpa/5/

Build URL
http://dev-charts-hpa-badgr-server-badgr-labs-dev.apps.dev.lxp.academy.who.int/

