### PR TITLE
fix: deprecated apiVersion on HPA and patch

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -8,7 +8,7 @@ version: 1.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.7.6
+appVersion: 1.7.7
 
 home: https://github.com/WHOAcademy/badgr-server
 

--- a/chart/templates/hpa.yaml
+++ b/chart/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta2 
+apiVersion: autoscaling/v2 
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "badgr.fullname" . }}-hpa
@@ -37,3 +37,4 @@ spec:
           periodSeconds: 60
       stabilizationWindowSeconds: 0
 {{ end }}
+


### PR DESCRIPTION
# Pull Request Template

**Description**
The current apiVersion being used is autoscaling/v2beta2 which was working in 4.8 version of OpenShift but is deprecated in the latest version of OpenShift 4.14.
Hence we have to update it to autoscaling/v2.

**Checks before making a PR**

- [x] Bumped version (package version)

 **JIRA**
 [Link to JIRA tickets](https://whoacademy.atlassian.net/browse/TTW-2695)